### PR TITLE
Hotfix/parse arrays only for checkbox enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.2.3
+- [hotfix] treat the incoming field as an array only when it's enumeration checkbox, other enumeration - select, radio is treated as a signle value field
+
 ## v0.2.2
 - [bugfix] move `ship:update` handler to background job so it doesn't interfere
 with refresh token operation (which triggers the update event) 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Hubspot",
   "description": "Sync a Hubspot Channel whenever a User enters or leaves a Segment",
   "picture": "picture.png",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "tags": [
     "outgoing",
     "incoming",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hull-hubspot",
   "description": "Send Notification of User events and segments to Hubspot",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "homepage": "https://github.com/hull-ships/hull-hubspot",
   "license": "MIT",
   "main": "bin/start",

--- a/server/lib/sync-agent/mapping.js
+++ b/server/lib/sync-agent/mapping.js
@@ -59,7 +59,8 @@ export default class Mapping {
           }
         }
 
-        if (hubspotProp && hubspotProp.type === "enumeration") {
+        if (hubspotProp && hubspotProp.type === "enumeration"
+          && hubspotProp.fieldType === "checkbox") {
           val = val.split(";");
         }
         traits[prop.hull] = val;


### PR DESCRIPTION
- [hotfix] treat the incoming field as an array only when it's enumeration checkbox, other enumeration - select, radio is treated as a signle value field